### PR TITLE
Fixed pick saved cb display

### DIFF
--- a/src/components/FightRow.tsx
+++ b/src/components/FightRow.tsx
@@ -197,6 +197,7 @@ export function FightRow({ fight, userPick: initialUserPick, eventDate, isEventC
                                     isLocked={isLocked}
                                     isEventCompleted={isEventCompleted}
                                     dict={dict}
+                                    onPickSaved={(pick) => setExistingPick(pick)}
                                 />
                             )}
                         </div>

--- a/src/components/PickForm.tsx
+++ b/src/components/PickForm.tsx
@@ -19,9 +19,10 @@ interface PickFormProps {
     isLocked?: boolean
     isEventCompleted?: boolean
     dict: any
+    onPickSaved?: (pick: { winner: string; method: string; round: number }) => void
 }
 
-export function PickForm({ fightId, fighterA, fighterB, scheduledRounds, existingPick, isLocked = false, isEventCompleted = false, dict }: PickFormProps) {
+export function PickForm({ fightId, fighterA, fighterB, scheduledRounds, existingPick, isLocked = false, isEventCompleted = false, dict, onPickSaved }: PickFormProps) {
 
     // State now uses DB codes directly: 'A'/'B' for winner, 'KO'/'SUB'/'DEC' for method
     // This avoids complex two-way binding of translated strings
@@ -61,12 +62,14 @@ export function PickForm({ fightId, fighterA, fighterB, scheduledRounds, existin
             toast.error(result.error)
         } else {
             // Update local saved state to reflect the success immediately
-            setSavedPick({
+            const newPick = {
                 winner: winnerCode,
                 method: method,
                 round: finalRound
-            })
+            }
+            setSavedPick(newPick)
             setHasSubmittedPick(true)
+            onPickSaved?.(newPick)
             toast.success(hasSubmittedPick ? dict.pickForm.pickUpdated : dict.pickForm.pickSavedSuccess)
         }
     }


### PR DESCRIPTION
Root cause: FightRow holds existingPick in its own state (initialized from the server-rendered prop). When a pick is submitted, PickForm only updated its own internal savedPick state — it never told FightRow. So when the user collapsed and re-expanded the row, PickForm remounted with existingPick={null} from FightRow's still-stale state, showing no selection (even though the pick was correctly saved to the DB).

Fix:
PickForm — added an optional onPickSaved callback prop. After a successful submission, it calls onPickSaved(newPick) to notify the parent.
FightRow — passes onPickSaved={(pick) => setExistingPick(pick)}, so its own existingPick state is immediately updated. The next time the user collapses and reopens the row, PickForm remounts with the correct pick already populated.